### PR TITLE
Fix endpoints in examples

### DIFF
--- a/quickstart/bash/main.sh
+++ b/quickstart/bash/main.sh
@@ -1,7 +1,7 @@
 # Example cURL Request
 
 ## To run locally
-curl --location with "http://localhost:2020" \
+curl --location with "http://localhost:2020/v1/{endpoint}" \
   --header 'Content-Type: application/json' \
   --data '{
     "image_url": "data:image/jpeg;base64,${cat ../images/frieren.jpg | base64}",

--- a/quickstart/node/main.js
+++ b/quickstart/node/main.js
@@ -2,7 +2,7 @@ import { vl } from "moondream";
 import fs from "fs";
 
 // this will run it against a local Moondream Server
-const model = new vl({ endpoint: "http://localhost:2020" });
+const model = new vl({ endpoint: "http://localhost:2020/v1" });
 
 // ...uncomment this line if you prefer to run it against Moondream Cloud
 // const model = new vl({ apiKey: "<your-api-key>" });

--- a/quickstart/python/main.py
+++ b/quickstart/python/main.py
@@ -2,7 +2,7 @@ import moondream as md
 from PIL import Image
 
 # This will run the model locally
-model = md.vl(endpoint="http://localhost:2020")
+model = md.vl(endpoint="http://localhost:2020/v1")
 
 # For Moondream Cloud, use your API key:
 # model = md.vl(api_key="<your-api-key>")


### PR DESCRIPTION
The examples were missing the required trailing /v1 in the endpoint configuration.