### PR TITLE
Add car detection example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The examples in this project work with Python, Node, and Bash. Most examples are
 Browse the examples contained, each one is fully functional, so you can run them as-is and tweak the code to suit your needs.
 
 - **QuickStart**: A hello world example showing how to call the model
+- **Detect Cars Tutorial**: Notebook showing how to detect cars in images and save the results
 
 ### Contributing
 

--- a/quickstart/python/README.md
+++ b/quickstart/python/README.md
@@ -22,3 +22,11 @@ Get started with Moondream's vision AI in Python in minutes.
    ```bash
    python main.py
    ```
+
+5. Detect cars in all images in the `../images` folder:
+
+   Open the `detect_cars.ipynb` notebook in Jupyter and run all the cells:
+
+   ```bash
+   jupyter notebook detect_cars.ipynb
+   ```

--- a/quickstart/python/detect_cars.ipynb
+++ b/quickstart/python/detect_cars.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Detect Cars Tutorial\n",
+    "This notebook shows how to detect cars in a folder of images using Moondream.\n",
+    "You'll see how to annotate a single image and then process an entire folder,\n",
+    "saving the overlayed images and a JSON summary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "from PIL import Image, ImageDraw\n",
+    "from IPython.display import display\n",
+    "import moondream as md\n",
+    "\n",
+    "# Initialize the model to run locally\n",
+    "model = md.vl(endpoint=\"http://localhost:2020/v1\")\n",
+    "# For Moondream Cloud use:\n",
+    "# model = md.vl(api_key=\"<your-api-key>\")\n",
+    "\n",
+    "INPUT_FOLDER = os.path.join(os.path.dirname(__file__), '..', '..', 'images')\n",
+    "OUTPUT_FOLDER = os.path.join(INPUT_FOLDER, 'detected')\n",
+    "os.makedirs(OUTPUT_FOLDER, exist_ok=True)\n",
+    "\n",
+    "image_files = [f for f in os.listdir(INPUT_FOLDER) if f.lower().endswith(('png','jpg','jpeg'))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detect a single image\n",
+    "Let's run detection on the first image and display the result with bounding boxes." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_path = os.path.join(INPUT_FOLDER, image_files[0])\n",
+    "first_image = Image.open(first_path)\n",
+    "detection = model.detect(first_image, 'car')['objects']\n",
+    "overlay = first_image.copy()\n",
+    "draw = ImageDraw.Draw(overlay)\n",
+    "for box in detection:\n",
+    "    draw.rectangle([box['x_min'], box['y_min'], box['x_max'], box['y_max']], outline='red', width=3)\n",
+    "display(overlay)\n",
+    "detection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process the entire folder\n",
+    "Now let's loop through all the images, saving overlayed versions and recording the results in a JSON file." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = []\n",
+    "for fname in image_files:\n",
+    "    img_path = os.path.join(INPUT_FOLDER, fname)\n",
+    "    img = Image.open(img_path)\n",
+    "    boxes = model.detect(img, 'car')['objects']\n",
+    "    ov = img.copy()\n",
+    "    d = ImageDraw.Draw(ov)\n",
+    "    for b in boxes:\n",
+    "        d.rectangle([b['x_min'], b['y_min'], b['x_max'], b['y_max']], outline='red', width=3)\n",
+    "    out_path = os.path.join(OUTPUT_FOLDER, fname)\n",
+    "    ov.save(out_path)\n",
+    "    results.append({'original': img_path, 'overlay': out_path, 'boxes': boxes})\n",
+    "\n",
+    "json_path = os.path.join(OUTPUT_FOLDER, 'results.json')\n",
+    "with open(json_path, 'w') as f:\n",
+    "    json.dump(results, f, indent=2)\n",
+    "\n",
+    "f'Saved {len(results)} results to {json_path}'"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/quickstart/python/detect_cars.py
+++ b/quickstart/python/detect_cars.py
@@ -1,0 +1,55 @@
+import os
+import json
+from PIL import Image, ImageDraw
+import moondream as md
+
+# This example detects cars in all images in a folder.
+# It saves overlay images with bounding boxes and a JSON summary.
+
+# Initialize Moondream for local inference
+model = md.vl(endpoint="http://localhost:2020/v1")
+# For Moondream Cloud, use your API key:
+# model = md.vl(api_key="<your-api-key>")
+
+INPUT_FOLDER = os.path.join(os.path.dirname(__file__), "..", "..", "images")
+OUTPUT_FOLDER = os.path.join(INPUT_FOLDER, "detected")
+
+os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+
+results = []
+
+for file_name in os.listdir(INPUT_FOLDER):
+    if not file_name.lower().endswith((".png", ".jpg", ".jpeg")):
+        continue
+
+    input_path = os.path.join(INPUT_FOLDER, file_name)
+    image = Image.open(input_path)
+
+    # Detect cars in the image
+    detection = model.detect(image, "car")["objects"]
+
+    # Draw bounding boxes on a copy of the image
+    overlay = image.copy()
+    draw = ImageDraw.Draw(overlay)
+    for box in detection:
+        draw.rectangle(
+            [box["x_min"], box["y_min"], box["x_max"], box["y_max"]],
+            outline="red",
+            width=3,
+        )
+
+    output_path = os.path.join(OUTPUT_FOLDER, file_name)
+    overlay.save(output_path)
+
+    results.append({
+        "original": input_path,
+        "overlay": output_path,
+        "boxes": detection,
+    })
+
+# Save detection results to JSON
+json_path = os.path.join(OUTPUT_FOLDER, "results.json")
+with open(json_path, "w") as f:
+    json.dump(results, f, indent=2)
+
+print(f"Saved {len(results)} results to {json_path}")


### PR DESCRIPTION
## Summary
- add Detect Cars tutorial notebook with single-image and batch examples
- document new notebook in root README
- update Python quickstart to run the notebook

## Testing
- `python -m py_compile quickstart/python/main.py quickstart/python/detect_cars.py`
- `python -m json.tool quickstart/python/detect_cars.ipynb >/dev/null`
