### PR TITLE
Expand detection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The examples in this project work with Python, Node, and Bash. Most examples are
 Browse the examples contained, each one is fully functional, so you can run them as-is and tweak the code to suit your needs.
 
 - **QuickStart**: A hello world example showing how to call the model
-- **Detect Cars Tutorial**: Notebook showing how to detect cars in images and save the results
+ - **Detect Cars Tutorial**: Notebook demonstrating caption, query, detect, and point while processing car images. Bounding boxes are normalized so the notebook converts them to pixels for overlays.
 
 ### Contributing
 

--- a/quickstart/python/README.md
+++ b/quickstart/python/README.md
@@ -23,10 +23,14 @@ Get started with Moondream's vision AI in Python in minutes.
    python main.py
    ```
 
-5. Detect cars in all images in the `../images` folder:
+5. Try the full tutorial in the `../images` folder:
 
-   Open the `detect_cars.ipynb` notebook in Jupyter and run all the cells:
+   Open the `detect_cars.ipynb` notebook in Jupyter and run all the cells to see caption, query, detect and point in action:
 
    ```bash
    jupyter notebook detect_cars.ipynb
    ```
+
+The tutorial demonstrates that bounding box and point coordinates are returned
+as proportions of the image. The notebook converts them to pixel coordinates
+before drawing overlays.

--- a/quickstart/python/detect_cars.ipynb
+++ b/quickstart/python/detect_cars.ipynb
@@ -4,10 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Detect Cars Tutorial\n",
-    "This notebook shows how to detect cars in a folder of images using Moondream.\n",
-    "You'll see how to annotate a single image and then process an entire folder,\n",
-    "saving the overlayed images and a JSON summary."
+     "# Detect Cars Tutorial\n",
+     "This notebook shows how to use every vision capability in Moondream.\n",
+     "You'll caption an image, ask a question about it, detect cars with boxes,\n",
+     "point to each car's center, and then process an entire folder, saving the\n",
+     "overlayed images and a JSON summary."
    ]
   },
   {
@@ -38,8 +39,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Detect a single image\n",
-    "Let's run detection on the first image and display the result with bounding boxes." 
+     "## Run all capabilities on one image\n",
+     "We'll caption the first image, ask a question, detect cars with boxes, and point to them." 
    ]
   },
   {
@@ -48,23 +49,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "first_path = os.path.join(INPUT_FOLDER, image_files[0])\n",
-    "first_image = Image.open(first_path)\n",
+     "first_path = os.path.join(INPUT_FOLDER, image_files[0])\n",
+     "first_image = Image.open(first_path)\n",
+     "caption = model.caption(first_image)['caption']\n",
+     "answer = model.query(first_image, \"What's in this image?\")['answer']\n",
     "detection = model.detect(first_image, 'car')['objects']\n",
+    "points = model.point(first_image, 'car')['points']\n",
     "overlay = first_image.copy()\n",
     "draw = ImageDraw.Draw(overlay)\n",
+    "w, h = overlay.size\n",
     "for box in detection:\n",
-    "    draw.rectangle([box['x_min'], box['y_min'], box['x_max'], box['y_max']], outline='red', width=3)\n",
-    "display(overlay)\n",
-    "detection"
+    "    draw.rectangle([\n",
+    "        int(box['x_min'] * w),\n",
+    "        int(box['y_min'] * h),\n",
+    "        int(box['x_max'] * w),\n",
+    "        int(box['y_max'] * h)\n",
+    "    ], outline='red', width=3)\n",
+    "for pt in points:\n",
+    "    r = 4\n",
+    "    draw.ellipse([\n",
+    "        int(pt['x'] * w) - r, int(pt['y'] * h) - r,\n",
+    "        int(pt['x'] * w) + r, int(pt['y'] * h) + r\n",
+    "    ], fill='blue')\n",
+     "display(overlay)\n",
+     "caption, answer, detection, points"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Process the entire folder\n",
-    "Now let's loop through all the images, saving overlayed versions and recording the results in a JSON file." 
+     "## Process the entire folder\n",
+     "Now let's run caption, query, detect, and point on every image, saving overlayed versions and recording the results in a JSON file."
    ]
   },
   {
@@ -73,18 +89,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = []\n",
-    "for fname in image_files:\n",
-    "    img_path = os.path.join(INPUT_FOLDER, fname)\n",
-    "    img = Image.open(img_path)\n",
+     "results = []\n",
+     "for fname in image_files:\n",
+     "    img_path = os.path.join(INPUT_FOLDER, fname)\n",
+     "    img = Image.open(img_path)\n",
+     "    caption = model.caption(img)['caption']\n",
+     "    answer = model.query(img, \"What's in this image?\")['answer']\n",
     "    boxes = model.detect(img, 'car')['objects']\n",
+    "    points = model.point(img, 'car')['points']\n",
     "    ov = img.copy()\n",
     "    d = ImageDraw.Draw(ov)\n",
+    "    w, h = ov.size\n",
     "    for b in boxes:\n",
-    "        d.rectangle([b['x_min'], b['y_min'], b['x_max'], b['y_max']], outline='red', width=3)\n",
-    "    out_path = os.path.join(OUTPUT_FOLDER, fname)\n",
-    "    ov.save(out_path)\n",
-    "    results.append({'original': img_path, 'overlay': out_path, 'boxes': boxes})\n",
+    "        d.rectangle([\n",
+    "            int(b['x_min'] * w),\n",
+    "            int(b['y_min'] * h),\n",
+    "            int(b['x_max'] * w),\n",
+    "            int(b['y_max'] * h)\n",
+    "        ], outline='red', width=3)\n",
+    "    for p in points:\n",
+    "        r = 4\n",
+    "        d.ellipse([\n",
+    "            int(p['x'] * w) - r, int(p['y'] * h) - r,\n",
+    "            int(p['x'] * w) + r, int(p['y'] * h) + r\n",
+    "        ], fill='blue')\n",
+     "    out_path = os.path.join(OUTPUT_FOLDER, fname)\n",
+     "    ov.save(out_path)\n",
+     "    results.append({'original': img_path, 'overlay': out_path, 'caption': caption, 'answer': answer, 'boxes': boxes, 'points': points})\n",
     "\n",
     "json_path = os.path.join(OUTPUT_FOLDER, 'results.json')\n",
     "with open(json_path, 'w') as f:\n",


### PR DESCRIPTION
## Summary
- expand detection script to showcase caption, query, detect and point
- convert normalized boxes/points to pixel coordinates before drawing overlays
- update the tutorial notebook with the same scaling logic
- document the normalized coordinates in the READMEs

## Testing
- `python -m py_compile quickstart/python/detect_cars.py`
- `jq '.' quickstart/python/detect_cars.ipynb > /dev/null`
