### PR TITLE
Add finetune examples for lens launch

### DIFF
--- a/quickstart/finetune/train_ballholder_detect.py
+++ b/quickstart/finetune/train_ballholder_detect.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_ballholder_detect.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import io
@@ -34,12 +34,6 @@ RANK = 8
 SEED = 42
 MAX_TOKENS = 32
 MAX_OBJECTS = 1
-
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
-
 
 def decode_image(image):
     if isinstance(image, Image.Image):
@@ -120,7 +114,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"ballholder-detect-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_ballholder_detect.py
+++ b/quickstart/finetune/train_ballholder_detect.py
@@ -1,0 +1,158 @@
+"""Simple detect finetuning example for ball-holder detection.
+
+Dataset: maxs-m87/Ball-Holder-splits-v1
+
+Requires:
+    pip install datasets pillow
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_ballholder_detect.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import io
+import json
+import os
+import time
+
+from datasets import load_dataset
+from PIL import Image
+
+import moondream as md
+
+DATASET_NAME = "maxs-m87/Ball-Holder-splits-v1"
+OBJECT_NAME = "player with the ball"
+
+STEPS = 100
+BATCH_SIZE = 8
+NUM_ROLLOUTS = 4
+EVAL_EVERY = 10
+LR = 2e-3
+RANK = 8
+SEED = 42
+MAX_TOKENS = 32
+MAX_OBJECTS = 1
+
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+
+
+def decode_image(image):
+    if isinstance(image, Image.Image):
+        return image.convert("RGB") if image.mode != "RGB" else image
+    if image.get("bytes") is not None:
+        with Image.open(io.BytesIO(image["bytes"])) as decoded:
+            return decoded.convert("RGB")
+    with Image.open(image["path"]) as decoded:
+        return decoded.convert("RGB")
+
+
+def parse_boxes(value):
+    return [
+        {
+            "x_min": box["x_min"],
+            "y_min": box["y_min"],
+            "x_max": box["x_max"],
+            "y_max": box["y_max"],
+        }
+        for box in json.loads(value or "[]")
+    ]
+
+
+def load_examples(split):
+    rows = load_dataset(
+        DATASET_NAME,
+        split=split,
+        token=os.environ.get("HF_TOKEN"),
+    ).shuffle(seed=SEED)
+
+    return [
+        {
+            "image": decode_image(row["image"]),
+            "boxes": parse_boxes(row["answer_boxes"]),
+        }
+        for row in rows
+    ]
+
+
+def detect_settings(temperature):
+    return {
+        "temperature": temperature,
+        "max_tokens": MAX_TOKENS,
+        "max_objects": MAX_OBJECTS,
+    }
+
+
+def request_stream(examples):
+    while True:
+        for example in examples:
+            yield example, {
+                "skill": "detect",
+                "image": example["image"],
+                "object": OBJECT_NAME,
+                "num_rollouts": NUM_ROLLOUTS,
+                "settings": detect_settings(1.0),
+                "ground_truth": {"boxes": example["boxes"]},
+            }
+
+
+def evaluate(ft, examples):
+    miou = 0.0
+    for example in examples:
+        response = ft.rollouts(
+            "detect",
+            image=example["image"],
+            object=OBJECT_NAME,
+            settings=detect_settings(0.0),
+            ground_truth={"boxes": example["boxes"]},
+        )
+        miou += response["rewards"][0]
+    return miou / len(examples)
+
+
+def main():
+    train_examples = load_examples("train")
+    eval_examples = load_examples("validation")
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"ballholder-detect-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    batch = []
+    for _, response in ft.rollout_stream(request_stream(train_examples)):
+        batch.append({
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response["rollouts"],
+            "rewards": response["rewards"],
+        })
+        if len(batch) < BATCH_SIZE:
+            continue
+
+        step = ft.train_step(batch, lr=LR)
+        batch = []
+        print(f"step={step['step']} reward_mean={step['reward_mean']:.4f}", flush=True)
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            eval_miou = evaluate(ft, eval_examples)
+            ft.log_metrics(step=step["step"], metrics={"eval/miou": eval_miou})
+            print(f"eval step={step['step']} miou={eval_miou:.4f}", flush=True)
+
+        if step["step"] == STEPS:
+            break
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_geoguessr_countries_query.py
+++ b/quickstart/finetune/train_geoguessr_countries_query.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_geoguessr_countries_query.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import io
@@ -33,11 +33,6 @@ LR = 2e-5
 RANK = 8
 SEED = 42
 MAX_TOKENS = 10
-
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
 
 COUNTRY_ALIASES = {
     "czech republic": "czechia",
@@ -144,7 +139,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"geoguessr-countries-query-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_geoguessr_countries_query.py
+++ b/quickstart/finetune/train_geoguessr_countries_query.py
@@ -1,0 +1,177 @@
+"""Simple query finetuning example for GeoGuessr country classification.
+
+Dataset: moondream/geoguessr-countries-finetune
+
+Requires:
+    pip install datasets pillow
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_geoguessr_countries_query.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import io
+import os
+import re
+import time
+import unicodedata
+
+from datasets import load_dataset
+from PIL import Image
+
+import moondream as md
+
+QUESTION = "What country is this, return only the name."
+
+STEPS = 20
+BATCH_SIZE = 16
+EVAL_EVERY = 5
+EVAL_LIMIT = 100
+LR = 2e-5
+RANK = 8
+SEED = 42
+MAX_TOKENS = 10
+
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+
+COUNTRY_ALIASES = {
+    "czech republic": "czechia",
+    "holland": "netherlands",
+    "the netherlands": "netherlands",
+    "russian federation": "russia",
+    "republic of korea": "south korea",
+    "turkiye": "turkey",
+    "britain": "united kingdom",
+    "england": "united kingdom",
+    "great britain": "united kingdom",
+    "u k": "united kingdom",
+    "uk": "united kingdom",
+    "america": "united states",
+    "u s": "united states",
+    "u s a": "united states",
+    "united states of america": "united states",
+    "us": "united states",
+    "usa": "united states",
+}
+
+
+def normalize_country(text):
+    country = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    country = " ".join(re.findall(r"[a-z0-9]+", country.lower()))
+    if country.startswith("the "):
+        country = country[4:]
+    return COUNTRY_ALIASES.get(country, country)
+
+
+def decode_image(image):
+    if isinstance(image, Image.Image):
+        return image.convert("RGB") if image.mode != "RGB" else image
+    if image.get("bytes") is not None:
+        with Image.open(io.BytesIO(image["bytes"])) as decoded:
+            return decoded.convert("RGB")
+    with Image.open(image["path"]) as decoded:
+        return decoded.convert("RGB")
+
+
+def load_eval_examples():
+    rows = load_dataset(
+        "moondream/geoguessr-countries-finetune",
+        split="test",
+        streaming=True,
+        token=os.environ.get("HF_TOKEN"),
+    ).shuffle(seed=SEED, buffer_size=1000)
+
+    examples = []
+    for row in rows:
+        row["image"] = decode_image(row["image"])
+        examples.append(row)
+        if len(examples) == EVAL_LIMIT:
+            break
+    return examples
+
+
+def train_groups():
+    epoch = 0
+    while True:
+        rows = load_dataset(
+            "moondream/geoguessr-countries-finetune",
+            split="train",
+            streaming=True,
+            token=os.environ.get("HF_TOKEN"),
+        ).shuffle(seed=SEED + epoch, buffer_size=1000)
+        epoch += 1
+
+        batch = []
+        for row in rows:
+            batch.append({
+                "mode": "sft",
+                "request": {
+                    "skill": "query",
+                    "image": decode_image(row["image"]),
+                    "question": QUESTION,
+                    "settings": {"temperature": 0.0, "max_tokens": MAX_TOKENS},
+                },
+                "target": {"answer": row["country"]},
+            })
+            if len(batch) == BATCH_SIZE:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+
+def evaluate(ft, examples):
+    correct = 0
+    for example in examples:
+        answer = ft.rollouts(
+            "query",
+            image=example["image"],
+            question=QUESTION,
+            settings={"temperature": 0.0, "max_tokens": MAX_TOKENS},
+        )["rollouts"][0]["output"]["answer"]
+        correct += normalize_country(answer) == normalize_country(example["country"])
+    return correct / len(examples)
+
+
+def main():
+    eval_examples = load_eval_examples()
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"geoguessr-countries-query-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    for groups in train_groups():
+        step = ft.train_step(groups, lr=LR)
+        print(f"step={step['step']} sft_loss={step['sft_loss']:.4f}", flush=True)
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            country_match = evaluate(ft, eval_examples)
+            ft.log_metrics(
+                step=step["step"],
+                metrics={"eval/country_match": country_match},
+            )
+            print(
+                f"eval step={step['step']} country_match={country_match:.3f}",
+                flush=True,
+            )
+
+        if step["step"] == STEPS:
+            break
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_glaucoma_query.py
+++ b/quickstart/finetune/train_glaucoma_query.py
@@ -1,0 +1,141 @@
+"""Simple query finetuning example for glaucoma stage classification.
+
+Dataset: moondream/glaucoma-detection
+
+Requires:
+    pip install datasets pillow
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_glaucoma_query.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import os
+import re
+import time
+
+from datasets import load_dataset
+
+import moondream as md
+
+QUESTION = (
+    "What stage of glaucoma is shown in this retinal image? "
+    "Respond with one of: normal, early, advanced only."
+)
+
+STEPS = 10
+NUM_ROLLOUTS = 4
+EVAL_EVERY = 5
+EVAL_LIMIT = 100
+LR = 0.001
+RANK = 8
+SEED = 42
+MAX_TOKENS = 10
+
+VALID_STAGES = ("normal", "early", "advanced")
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+
+
+def load_examples(target_split, limit=None, shuffle=False):
+    rows = load_dataset(
+        "moondream/glaucoma-detection",
+        split=target_split,
+        streaming=True,
+        token=os.environ.get("HF_TOKEN"),
+    )
+    if shuffle:
+        rows = rows.shuffle(seed=SEED, buffer_size=1000)
+
+    examples = []
+    for row in rows:
+        examples.append(row)
+        if limit is not None and len(examples) == limit:
+            break
+    return examples
+
+
+def normalize_stage(text):
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    for stage in VALID_STAGES:
+        if stage in words:
+            return stage
+    return ""
+
+
+def request_stream(examples):
+    while True:
+        for example in examples:
+            yield example, {
+                "skill": "query",
+                "image": example["image"],
+                "question": QUESTION,
+                "num_rollouts": NUM_ROLLOUTS,
+                "settings": {"temperature": 1.0, "max_tokens": MAX_TOKENS},
+            }
+
+
+def evaluate(ft, examples):
+    correct = 0
+    for example in examples:
+        answer = ft.rollouts(
+            "query",
+            image=example["image"],
+            question=QUESTION,
+            settings={"temperature": 0.0, "max_tokens": MAX_TOKENS},
+        )["rollouts"][0]["output"]["answer"]
+        correct += normalize_stage(answer) == example["class"]
+    return correct / len(examples)
+
+
+def main():
+    train_examples = load_examples("train", shuffle=True)
+    eval_examples = load_examples("validation", limit=EVAL_LIMIT, shuffle=True)
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"glaucoma-query-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    for _, (example, response) in zip(
+        range(STEPS),
+        ft.rollout_stream(request_stream(train_examples)),
+    ):
+        rewards = [
+            float(normalize_stage(r["output"]["answer"]) == example["class"])
+            for r in response["rollouts"]
+        ]
+        step = ft.train_step([{
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response["rollouts"],
+            "rewards": rewards,
+        }], lr=LR)
+        reward_mean = sum(rewards) / len(rewards)
+        print(
+            f"step={step['step']} label={example['class']} reward_mean={reward_mean:.3f}",
+            flush=True,
+        )
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            eval_accuracy = evaluate(ft, eval_examples)
+            ft.log_metrics(step=step["step"], metrics={"eval/accuracy": eval_accuracy})
+            print(
+                f"eval step={step['step']} accuracy={eval_accuracy:.3f}",
+                flush=True,
+            )
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_glaucoma_query.py
+++ b/quickstart/finetune/train_glaucoma_query.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_glaucoma_query.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import os
@@ -35,10 +35,6 @@ SEED = 42
 MAX_TOKENS = 10
 
 VALID_STAGES = ("normal", "early", "advanced")
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
 
 
 def load_examples(target_split, limit=None, shuffle=False):
@@ -98,7 +94,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"glaucoma-query-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_ishape_antenna_detect.py
+++ b/quickstart/finetune/train_ishape_antenna_detect.py
@@ -13,7 +13,9 @@ Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
 """
 
 import io
+import math
 import os
+import statistics
 import time
 
 from datasets import load_dataset
@@ -35,6 +37,9 @@ RANK = 32
 SEED = 42
 MAX_TOKENS = 256
 MAX_OBJECTS = None
+GROUND_TRUTH_INJECTION_STD_THRESH = 0.1
+GROUND_TRUTH_INJECTION_MAX_REWARD = 0.4
+GROUND_TRUTH_INJECTION_REWARD_SCALE = 2.0
 
 TUNING_ENDPOINT = os.environ.get(
     "MOONDREAM_TUNING_ENDPOINT",
@@ -91,6 +96,117 @@ def detect_settings(temperature):
     return settings
 
 
+def quantize_coord(value):
+    return max(0, min(1023, int(round(float(value) * 1023))))
+
+
+def quantize_size(value):
+    value = max(float(value), 2**-10)
+    return max(0, min(1023, int(round((math.log2(value) + 10) / 10 * 1023))))
+
+
+def pad_boxes(boxes, target_boxes):
+    padded = list(boxes[:target_boxes])
+    while len(padded) < target_boxes:
+        padded.append({"x_min": 0.0, "y_min": 0.0, "x_max": 0.0, "y_max": 0.0})
+    return padded
+
+
+def encode_boxes(boxes, target_boxes):
+    coords = []
+    sizes = []
+    for box in boxes[:target_boxes]:
+        x_center = (box["x_min"] + box["x_max"]) / 2.0
+        y_center = (box["y_min"] + box["y_max"]) / 2.0
+        width = box["x_max"] - box["x_min"]
+        height = box["y_max"] - box["y_min"]
+        coords.extend([quantize_coord(x_center), quantize_coord(y_center)])
+        sizes.append([quantize_size(width), quantize_size(height)])
+
+    while len(sizes) < target_boxes:
+        coords.extend([0, 0])
+        sizes.append([0, 0])
+
+    return coords, sizes
+
+
+def rollout_box_count(rollout):
+    coords = rollout.get("coords", [])
+    sizes = rollout.get("sizes", [])
+    if len(coords) % 2 != 0:
+        return None
+    coord_boxes = len(coords) // 2
+    if sizes and coord_boxes and len(sizes) != coord_boxes:
+        return None
+    if sizes:
+        return len(sizes)
+    if coord_boxes:
+        return coord_boxes
+    return len(rollout.get("output", {}).get("objects", []))
+
+
+def detect_token_ids(rollout):
+    tokens = rollout.get("answer_tokens", [])
+    if len(tokens) < 3:
+        return None
+    return tokens[0], tokens[2]
+
+
+def build_ground_truth_rollout(rollout, gt_boxes, target_boxes):
+    token_ids = detect_token_ids(rollout)
+    if token_ids is None:
+        return None
+
+    coord_id, size_id = token_ids
+    injected_boxes = pad_boxes(gt_boxes, target_boxes)
+    coords, sizes = encode_boxes(injected_boxes, target_boxes)
+    return {
+        "skill": rollout.get("skill", "detect"),
+        "finish_reason": rollout["finish_reason"],
+        "output": {"objects": injected_boxes},
+        "answer_tokens": [coord_id, coord_id, size_id] * target_boxes,
+        "thinking_tokens": list(rollout.get("thinking_tokens", [])),
+        "has_answer_separator": rollout.get("has_answer_separator", False),
+        "coords": coords,
+        "sizes": sizes,
+    }
+
+
+def maybe_inject_ground_truth(rollouts, rewards, gt_boxes):
+    if not rollouts or not rewards:
+        return rollouts, rewards, 0
+
+    reward_std = statistics.pstdev(rewards) if len(rewards) > 1 else 0.0
+    max_reward = max(rewards)
+    if (
+        reward_std >= GROUND_TRUTH_INJECTION_STD_THRESH
+        or max_reward >= GROUND_TRUTH_INJECTION_MAX_REWARD
+    ):
+        return rollouts, rewards, 0
+
+    replace_idx = min(range(len(rewards)), key=rewards.__getitem__)
+    target_boxes = rollout_box_count(rollouts[replace_idx]) or len(gt_boxes)
+    if target_boxes <= 0:
+        return rollouts, rewards, 0
+
+    injected_rollout = build_ground_truth_rollout(
+        rollouts[replace_idx],
+        gt_boxes,
+        target_boxes,
+    )
+    if injected_rollout is None:
+        return rollouts, rewards, 0
+
+    rollouts = list(rollouts)
+    rewards = list(rewards)
+    rollouts[replace_idx] = injected_rollout
+    rewards[replace_idx] = max(
+        0.5,
+        min(1.0, GROUND_TRUTH_INJECTION_REWARD_SCALE * max_reward),
+    )
+    return rollouts, rewards, 1
+
+
 def request_stream(examples):
     while True:
         for example in examples:
@@ -131,19 +247,30 @@ def main():
     print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
 
     batch = []
-    for _, response in ft.rollout_stream(request_stream(train_examples)):
+    batch_gt_injected = 0
+    for example, response in ft.rollout_stream(request_stream(train_examples)):
+        rollouts, rewards, gt_injected = maybe_inject_ground_truth(
+            response["rollouts"],
+            response["rewards"],
+            example["boxes"],
+        )
+        batch_gt_injected += gt_injected
         batch.append({
             "mode": "rl",
             "request": response["request"],
-            "rollouts": response["rollouts"],
-            "rewards": response["rewards"],
+            "rollouts": rollouts,
+            "rewards": rewards,
         })
         if len(batch) < BATCH_SIZE:
             continue
 
         step = ft.train_step(batch, lr=LR)
         batch = []
-        print(f"step={step['step']} reward_mean={step['reward_mean']:.4f}", flush=True)
+        print(
+            f"step={step['step']} reward_mean={step['reward_mean']:.4f} gt_injected={batch_gt_injected}",
+            flush=True,
+        )
+        batch_gt_injected = 0
 
         if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
             eval_miou = evaluate(ft, eval_examples)

--- a/quickstart/finetune/train_ishape_antenna_detect.py
+++ b/quickstart/finetune/train_ishape_antenna_detect.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_ishape_antenna_detect.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import io
@@ -40,12 +40,6 @@ MAX_OBJECTS = None
 GROUND_TRUTH_INJECTION_STD_THRESH = 0.1
 GROUND_TRUTH_INJECTION_MAX_REWARD = 0.4
 GROUND_TRUTH_INJECTION_REWARD_SCALE = 2.0
-
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
-
 
 def decode_image(image):
     if isinstance(image, Image.Image):
@@ -192,7 +186,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"ishape-antenna-detect-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_ishape_antenna_detect.py
+++ b/quickstart/finetune/train_ishape_antenna_detect.py
@@ -1,0 +1,162 @@
+"""Simple detect finetuning example for iShape antenna detection.
+
+Dataset: moondream/ishape-antenna
+
+Requires:
+    pip install datasets pillow pycocotools
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_ishape_antenna_detect.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import io
+import os
+import time
+
+from datasets import load_dataset
+from PIL import Image
+from pycocotools import mask as mask_utils
+
+import moondream as md
+
+DATASET_NAME = "moondream/ishape-antenna"
+OBJECT_NAME = "antenna"
+
+STEPS = 100
+BATCH_SIZE = 32
+NUM_ROLLOUTS = 8
+EVAL_EVERY = 10
+EVAL_LIMIT = 50
+LR = 2e-4
+RANK = 32
+SEED = 42
+MAX_TOKENS = 256
+MAX_OBJECTS = None
+
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+
+
+def decode_image(image):
+    if isinstance(image, Image.Image):
+        return image.convert("RGB") if image.mode != "RGB" else image
+    if image.get("bytes") is not None:
+        with Image.open(io.BytesIO(image["bytes"])) as decoded:
+            return decoded.convert("RGB")
+    with Image.open(image["path"]) as decoded:
+        return decoded.convert("RGB")
+
+
+def rle_to_box(rle):
+    height, width, counts = rle.split(" ", 2)
+    x, y, w, h = mask_utils.toBbox({
+        "size": [int(height), int(width)],
+        "counts": counts.encode("ascii"),
+    }).tolist()
+    return {
+        "x_min": x / int(width),
+        "y_min": y / int(height),
+        "x_max": (x + w) / int(width),
+        "y_max": (y + h) / int(height),
+    }
+
+
+def load_examples(split, limit=None):
+    rows = load_dataset(
+        DATASET_NAME,
+        split=split,
+        token=os.environ.get("HF_TOKEN"),
+    ).shuffle(seed=SEED)
+
+    examples = []
+    for row in rows:
+        boxes = [rle_to_box(obj["rle"]) for obj in row["objects"] if obj["name"] == OBJECT_NAME]
+        if not boxes:
+            continue
+        examples.append({"image": decode_image(row["image"]), "boxes": boxes})
+        if limit is not None and len(examples) == limit:
+            break
+    return examples
+
+
+def detect_settings(temperature):
+    settings = {"temperature": temperature, "max_tokens": MAX_TOKENS}
+    if MAX_OBJECTS is not None:
+        settings["max_objects"] = MAX_OBJECTS
+    return settings
+
+
+def request_stream(examples):
+    while True:
+        for example in examples:
+            yield example, {
+                "skill": "detect",
+                "image": example["image"],
+                "object": OBJECT_NAME,
+                "num_rollouts": NUM_ROLLOUTS,
+                "settings": detect_settings(1.0),
+                "ground_truth": {"boxes": example["boxes"]},
+            }
+
+
+def evaluate(ft, examples):
+    miou = 0.0
+    for example in examples:
+        response = ft.rollouts(
+            "detect",
+            image=example["image"],
+            object=OBJECT_NAME,
+            settings=detect_settings(0.0),
+            ground_truth={"boxes": example["boxes"]},
+        )
+        miou += response["rewards"][0]
+    return miou / len(examples)
+
+
+def main():
+    train_examples = load_examples("train")
+    eval_examples = load_examples("validation", limit=EVAL_LIMIT)
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"ishape-antenna-detect-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    batch = []
+    for _, response in ft.rollout_stream(request_stream(train_examples)):
+        batch.append({
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response["rollouts"],
+            "rewards": response["rewards"],
+        })
+        if len(batch) < BATCH_SIZE:
+            continue
+
+        step = ft.train_step(batch, lr=LR)
+        batch = []
+        print(f"step={step['step']} reward_mean={step['reward_mean']:.4f}", flush=True)
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            eval_miou = evaluate(ft, eval_examples)
+            ft.log_metrics(step=step["step"], metrics={"eval/miou": eval_miou})
+            print(f"eval step={step['step']} miou={eval_miou:.4f}", flush=True)
+
+        if step["step"] == STEPS:
+            break
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_ishape_antenna_detect.py
+++ b/quickstart/finetune/train_ishape_antenna_detect.py
@@ -105,77 +105,41 @@ def quantize_size(value):
     return max(0, min(1023, int(round((math.log2(value) + 10) / 10 * 1023))))
 
 
-def pad_boxes(boxes, target_boxes):
-    padded = list(boxes[:target_boxes])
-    while len(padded) < target_boxes:
-        padded.append({"x_min": 0.0, "y_min": 0.0, "x_max": 0.0, "y_max": 0.0})
-    return padded
-
-
 def encode_boxes(boxes, target_boxes):
+    boxes = list(boxes[:target_boxes])
+    while len(boxes) < target_boxes:
+        boxes.append({"x_min": 0.0, "y_min": 0.0, "x_max": 0.0, "y_max": 0.0})
+
     coords = []
     sizes = []
-    for box in boxes[:target_boxes]:
+    for box in boxes:
         x_center = (box["x_min"] + box["x_max"]) / 2.0
         y_center = (box["y_min"] + box["y_max"]) / 2.0
         width = box["x_max"] - box["x_min"]
         height = box["y_max"] - box["y_min"]
         coords.extend([quantize_coord(x_center), quantize_coord(y_center)])
         sizes.append([quantize_size(width), quantize_size(height)])
-
-    while len(sizes) < target_boxes:
-        coords.extend([0, 0])
-        sizes.append([0, 0])
-
-    return coords, sizes
+    return boxes, coords, sizes
 
 
-def rollout_box_count(rollout):
-    coords = rollout.get("coords", [])
-    sizes = rollout.get("sizes", [])
-    if len(coords) % 2 != 0:
-        return None
-    coord_boxes = len(coords) // 2
-    if sizes and coord_boxes and len(sizes) != coord_boxes:
-        return None
-    if sizes:
-        return len(sizes)
-    if coord_boxes:
-        return coord_boxes
-    return len(rollout.get("output", {}).get("objects", []))
-
-
-def detect_token_ids(rollout):
-    tokens = rollout.get("answer_tokens", [])
-    if len(tokens) < 3:
-        return None
-    return tokens[0], tokens[2]
-
-
-def build_ground_truth_rollout(rollout, gt_boxes, target_boxes):
-    token_ids = detect_token_ids(rollout)
-    if token_ids is None:
-        return None
-
-    coord_id, size_id = token_ids
-    injected_boxes = pad_boxes(gt_boxes, target_boxes)
-    coords, sizes = encode_boxes(injected_boxes, target_boxes)
+def build_ground_truth_rollout(rollout, gt_boxes):
+    target_boxes = len(rollout["sizes"]) or len(gt_boxes)
+    coord_id = rollout["answer_tokens"][0]
+    size_id = rollout["answer_tokens"][2]
+    boxes, coords, sizes = encode_boxes(gt_boxes, target_boxes)
     return {
-        "skill": rollout.get("skill", "detect"),
+        "skill": rollout["skill"],
         "finish_reason": rollout["finish_reason"],
-        "output": {"objects": injected_boxes},
+        "output": {"objects": boxes},
         "answer_tokens": [coord_id, coord_id, size_id] * target_boxes,
-        "thinking_tokens": list(rollout.get("thinking_tokens", [])),
-        "has_answer_separator": rollout.get("has_answer_separator", False),
+        "thinking_tokens": list(rollout["thinking_tokens"]),
+        "has_answer_separator": rollout["has_answer_separator"],
         "coords": coords,
         "sizes": sizes,
     }
 
 
 def maybe_inject_ground_truth(rollouts, rewards, gt_boxes):
-    if not rollouts or not rewards:
-        return rollouts, rewards, 0
-
     reward_std = statistics.pstdev(rewards) if len(rewards) > 1 else 0.0
     max_reward = max(rewards)
     if (
@@ -185,21 +149,9 @@ def maybe_inject_ground_truth(rollouts, rewards, gt_boxes):
         return rollouts, rewards, 0
 
     replace_idx = min(range(len(rewards)), key=rewards.__getitem__)
-    target_boxes = rollout_box_count(rollouts[replace_idx]) or len(gt_boxes)
-    if target_boxes <= 0:
-        return rollouts, rewards, 0
-
-    injected_rollout = build_ground_truth_rollout(
-        rollouts[replace_idx],
-        gt_boxes,
-        target_boxes,
-    )
-    if injected_rollout is None:
-        return rollouts, rewards, 0
-
     rollouts = list(rollouts)
     rewards = list(rewards)
-    rollouts[replace_idx] = injected_rollout
+    rollouts[replace_idx] = build_ground_truth_rollout(rollouts[replace_idx], gt_boxes)
     rewards[replace_idx] = max(
         0.5,
         min(1.0, GROUND_TRUTH_INJECTION_REWARD_SCALE * max_reward),

--- a/quickstart/finetune/train_ishape_logs_detect.py
+++ b/quickstart/finetune/train_ishape_logs_detect.py
@@ -1,0 +1,162 @@
+"""Simple detect finetuning example for iShape log detection.
+
+Dataset: moondream/ishape-logs
+
+Requires:
+    pip install datasets pillow pycocotools
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_ishape_logs_detect.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import io
+import os
+import time
+
+from datasets import load_dataset
+from PIL import Image
+from pycocotools import mask as mask_utils
+
+import moondream as md
+
+DATASET_NAME = "moondream/ishape-logs"
+OBJECT_NAME = "log"
+
+STEPS = 50
+BATCH_SIZE = 16
+NUM_ROLLOUTS = 8
+EVAL_EVERY = 10
+EVAL_LIMIT = 100
+LR = 8e-5
+RANK = 8
+SEED = 42
+MAX_TOKENS = 256
+MAX_OBJECTS = None
+
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+
+
+def decode_image(image):
+    if isinstance(image, Image.Image):
+        return image.convert("RGB") if image.mode != "RGB" else image
+    if image.get("bytes") is not None:
+        with Image.open(io.BytesIO(image["bytes"])) as decoded:
+            return decoded.convert("RGB")
+    with Image.open(image["path"]) as decoded:
+        return decoded.convert("RGB")
+
+
+def rle_to_box(rle):
+    height, width, counts = rle.split(" ", 2)
+    x, y, w, h = mask_utils.toBbox({
+        "size": [int(height), int(width)],
+        "counts": counts.encode("ascii"),
+    }).tolist()
+    return {
+        "x_min": x / int(width),
+        "y_min": y / int(height),
+        "x_max": (x + w) / int(width),
+        "y_max": (y + h) / int(height),
+    }
+
+
+def load_examples(split, limit=None):
+    rows = load_dataset(
+        DATASET_NAME,
+        split=split,
+        token=os.environ.get("HF_TOKEN"),
+    ).shuffle(seed=SEED)
+
+    examples = []
+    for row in rows:
+        boxes = [rle_to_box(obj["rle"]) for obj in row["objects"] if obj["name"] == OBJECT_NAME]
+        if not boxes:
+            continue
+        examples.append({"image": decode_image(row["image"]), "boxes": boxes})
+        if limit is not None and len(examples) == limit:
+            break
+    return examples
+
+
+def detect_settings(temperature):
+    settings = {"temperature": temperature, "max_tokens": MAX_TOKENS}
+    if MAX_OBJECTS is not None:
+        settings["max_objects"] = MAX_OBJECTS
+    return settings
+
+
+def request_stream(examples):
+    while True:
+        for example in examples:
+            yield example, {
+                "skill": "detect",
+                "image": example["image"],
+                "object": OBJECT_NAME,
+                "num_rollouts": NUM_ROLLOUTS,
+                "settings": detect_settings(1.0),
+                "ground_truth": {"boxes": example["boxes"]},
+            }
+
+
+def evaluate(ft, examples):
+    miou = 0.0
+    for example in examples:
+        response = ft.rollouts(
+            "detect",
+            image=example["image"],
+            object=OBJECT_NAME,
+            settings=detect_settings(0.0),
+            ground_truth={"boxes": example["boxes"]},
+        )
+        miou += response["rewards"][0]
+    return miou / len(examples)
+
+
+def main():
+    train_examples = load_examples("train")
+    eval_examples = load_examples("validation", limit=EVAL_LIMIT)
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"ishape-logs-detect-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    batch = []
+    for _, response in ft.rollout_stream(request_stream(train_examples)):
+        batch.append({
+            "mode": "rl",
+            "request": response["request"],
+            "rollouts": response["rollouts"],
+            "rewards": response["rewards"],
+        })
+        if len(batch) < BATCH_SIZE:
+            continue
+
+        step = ft.train_step(batch, lr=LR)
+        batch = []
+        print(f"step={step['step']} reward_mean={step['reward_mean']:.4f}", flush=True)
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            eval_miou = evaluate(ft, eval_examples)
+            ft.log_metrics(step=step["step"], metrics={"eval/miou": eval_miou})
+            print(f"eval step={step['step']} miou={eval_miou:.4f}", flush=True)
+
+        if step["step"] == STEPS:
+            break
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_ishape_logs_detect.py
+++ b/quickstart/finetune/train_ishape_logs_detect.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_ishape_logs_detect.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import io
@@ -35,12 +35,6 @@ RANK = 8
 SEED = 42
 MAX_TOKENS = 256
 MAX_OBJECTS = None
-
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
-
 
 def decode_image(image):
     if isinstance(image, Image.Image):
@@ -124,7 +118,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"ishape-logs-detect-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_ssv2_3x3_query.py
+++ b/quickstart/finetune/train_ssv2_3x3_query.py
@@ -1,0 +1,180 @@
+"""Simple query finetuning example for SSV2 3x3 action recognition.
+
+Dataset: moondream/ssv2-3x3
+
+Requires:
+    pip install datasets pillow
+
+To run with a local moondream-python checkout:
+    PYTHONPATH=/path/to/moondream-python python train_ssv2_3x3_query.py
+
+Set MOONDREAM_API_KEY.
+Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+"""
+
+import io
+import os
+import re
+import time
+from collections import Counter
+
+from datasets import load_dataset
+from PIL import Image
+
+import moondream as md
+
+QUESTION = "This is a 3x3 grid of frames from a video. What action is happening?"
+
+STEPS = 20
+BATCH_SIZE = 16
+EVAL_EVERY = 5
+EVAL_LIMIT = 100
+LR = 2e-5
+RANK = 8
+SEED = 42
+MAX_TOKENS = 20
+
+TUNING_ENDPOINT = os.environ.get(
+    "MOONDREAM_TUNING_ENDPOINT",
+    "https://api.moondream.ai/v1/tuning",
+)
+_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def normalize_text(text):
+    return " ".join(_NORMALIZE_RE.sub(" ", text.lower()).split())
+
+
+def token_f1(prediction, target):
+    pred_tokens = normalize_text(prediction).split()
+    target_tokens = normalize_text(target).split()
+    if not pred_tokens or not target_tokens:
+        return 0.0
+
+    pred_counts = Counter(pred_tokens)
+    target_counts = Counter(target_tokens)
+    overlap = sum(
+        min(pred_counts[token], target_counts[token])
+        for token in pred_counts.keys() & target_counts.keys()
+    )
+    if overlap == 0:
+        return 0.0
+
+    precision = overlap / len(pred_tokens)
+    recall = overlap / len(target_tokens)
+    return 2.0 * precision * recall / (precision + recall)
+
+
+def decode_image(image):
+    if isinstance(image, Image.Image):
+        return image.convert("RGB") if image.mode != "RGB" else image
+    if image.get("bytes") is not None:
+        with Image.open(io.BytesIO(image["bytes"])) as decoded:
+            return decoded.convert("RGB")
+    with Image.open(image["path"]) as decoded:
+        return decoded.convert("RGB")
+
+
+def load_eval_examples():
+    rows = load_dataset(
+        "moondream/ssv2-3x3",
+        split="test",
+        streaming=True,
+        token=os.environ.get("HF_TOKEN"),
+    ).shuffle(seed=SEED, buffer_size=1000)
+
+    examples = []
+    for row in rows:
+        row["image"] = decode_image(row["image"])
+        examples.append(row)
+        if len(examples) == EVAL_LIMIT:
+            break
+    return examples
+
+
+def train_groups():
+    epoch = 0
+    while True:
+        rows = load_dataset(
+            "moondream/ssv2-3x3",
+            split="train",
+            streaming=True,
+            token=os.environ.get("HF_TOKEN"),
+        ).shuffle(seed=SEED + epoch, buffer_size=1000)
+        epoch += 1
+
+        batch = []
+        for row in rows:
+            batch.append({
+                "mode": "sft",
+                "request": {
+                    "skill": "query",
+                    "image": decode_image(row["image"]),
+                    "question": QUESTION,
+                    "settings": {"temperature": 0.0, "max_tokens": MAX_TOKENS},
+                },
+                "target": {"answer": row["annotation_text"]},
+            })
+            if len(batch) == BATCH_SIZE:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+
+def evaluate(ft, examples):
+    exact_matches = 0
+    token_f1_sum = 0.0
+    for example in examples:
+        answer = ft.rollouts(
+            "query",
+            image=example["image"],
+            question=QUESTION,
+            settings={"temperature": 0.0, "max_tokens": MAX_TOKENS},
+        )["rollouts"][0]["output"]["answer"]
+        exact_matches += normalize_text(answer) == normalize_text(example["annotation_text"])
+        token_f1_sum += token_f1(answer, example["annotation_text"])
+    total = len(examples)
+    return exact_matches / total, token_f1_sum / total
+
+
+def main():
+    eval_examples = load_eval_examples()
+
+    ft = md.ft(
+        api_key=os.environ["MOONDREAM_API_KEY"],
+        endpoint=TUNING_ENDPOINT,
+        name=f"ssv2-3x3-query-{int(time.time())}",
+        rank=RANK,
+    )
+    print(f"Created finetune: {ft.finetune_id} ({ft.name})", flush=True)
+
+    for groups in train_groups():
+        step = ft.train_step(groups, lr=LR)
+        print(f"step={step['step']} sft_loss={step['sft_loss']:.4f}", flush=True)
+
+        if step["step"] % EVAL_EVERY == 0 or step["step"] == STEPS:
+            exact_match, mean_token_f1 = evaluate(ft, eval_examples)
+            ft.log_metrics(
+                step=step["step"],
+                metrics={
+                    "eval/exact_match": exact_match,
+                    "eval/token_f1": mean_token_f1,
+                },
+            )
+            print(
+                f"eval step={step['step']} exact_match={exact_match:.3f} token_f1={mean_token_f1:.3f}",
+                flush=True,
+            )
+
+        if step["step"] == STEPS:
+            break
+
+    checkpoint = ft.save_checkpoint()["checkpoint"]
+    print(f"Saved checkpoint: {checkpoint['checkpoint_id']}", flush=True)
+    print(f"Model ID: {ft.model(checkpoint['step'])}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/quickstart/finetune/train_ssv2_3x3_query.py
+++ b/quickstart/finetune/train_ssv2_3x3_query.py
@@ -9,7 +9,7 @@ To run with a local moondream-python checkout:
     PYTHONPATH=/path/to/moondream-python python train_ssv2_3x3_query.py
 
 Set MOONDREAM_API_KEY.
-Optional: HF_TOKEN, MOONDREAM_TUNING_ENDPOINT.
+Optional: HF_TOKEN.
 """
 
 import io
@@ -34,10 +34,6 @@ RANK = 32
 SEED = 42
 MAX_TOKENS = 20
 
-TUNING_ENDPOINT = os.environ.get(
-    "MOONDREAM_TUNING_ENDPOINT",
-    "https://api.moondream.ai/v1/tuning",
-)
 _NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -144,7 +140,6 @@ def main():
 
     ft = md.ft(
         api_key=os.environ["MOONDREAM_API_KEY"],
-        endpoint=TUNING_ENDPOINT,
         name=f"ssv2-3x3-query-{int(time.time())}",
         rank=RANK,
     )

--- a/quickstart/finetune/train_ssv2_3x3_query.py
+++ b/quickstart/finetune/train_ssv2_3x3_query.py
@@ -26,11 +26,11 @@ import moondream as md
 QUESTION = "This is a 3x3 grid of frames from a video. What action is happening?"
 
 STEPS = 20
-BATCH_SIZE = 16
+BATCH_SIZE = 128
 EVAL_EVERY = 5
 EVAL_LIMIT = 100
-LR = 2e-5
-RANK = 8
+LR = 2e-4
+RANK = 32
 SEED = 42
 MAX_TOKENS = 20
 


### PR DESCRIPTION
## Summary
Adding example finetune scripts for lens launch. This PR will be updated as more scripts land.

## Scripts
- `quickstart/finetune/train_glaucoma_query.py`: Query RL finetune example for glaucoma stage classification using `moondream/glaucoma-detection`.

## Validation
- `python3 -m py_compile quickstart/finetune/train_glaucoma_query.py`
- 2-step staging smoke test from `/workspace` on the SSH machine